### PR TITLE
Tolerate invalid JSON response from EPG API

### DIFF
--- a/include.js
+++ b/include.js
@@ -68,7 +68,11 @@ async function get_epg(channel, start, to) {
     url += `&channel=${prog}`;
   }
   const response = await fetch(url);
-  const epg = await response.json();
+  let epg = await response.text();
+  // Sometimes the TVHeadend API returns an unparseable string due to strange control
+  // characters within the subtitle/summary fields, so here we strip them in advance.
+  epg = epg.replace(/[\u0000-\u001F\u007F-\u009F]/g, "");
+  epg = JSON.parse(epg);
   return epg.entries;
 }
 


### PR DESCRIPTION
First off, thanks for creating TVHadmin-JS! I use it on a daily basis, and it's _so_ much better than the built-in THHeadend EPG. Great work.

Quite frequently (several times per day for me) the Timeline view fails to render, because the EPG API returns an invalid JSON body. It appears that there are some strange control characters being returned in the `summary` and `subtitle` fields. This simple patch strips out the ASCII control character range from the API response before attempting to parse the string as JSON. This fixes my issue, and hopefully will be useful to others with the same issue.

I hope you can find the time to review this small contribution - Thanks in advance!